### PR TITLE
Auto parsing: add new pattern for generic texthooker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anki-jpdb.reader",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Japanese text parsing + sentence mining with JPDB and Anki",
   "private": true,
   "scripts": {

--- a/src/hosts.json
+++ b/src/hosts.json
@@ -15,7 +15,8 @@
     "host": [
       "*://anacreondjt.gitlab.io/texthooker.html",
       "*://learnjapanese.moe/texthooker.html",
-      "*://renji-xd.github.io/texthooker-ui/"
+      "*://renji-xd.github.io/texthooker-ui/",
+      "*://*/texthooker$"
     ],
     "auto": true,
     "allFrames": false,


### PR DESCRIPTION
Very basic change that shouldn't really have any downsides.

I am implementing a texthooker into [my app](https://github.com/bpwhelan/GameSentenceMiner). and this would make it to where anki-jpdb.reader can do auto parsing on anything that just ends with "texthooker"

in my case:
```
http://localhost:3000/texthooker
```

But this would purposefully not match:
```
http://whatisatexthooker.domain
```

I am willing to be flexible, but this would be very helpful to get merged.